### PR TITLE
Store zip codes to avoid unnecesary calls to fetchState

### DIFF
--- a/packages/client/src/comp/Blurb.tsx
+++ b/packages/client/src/comp/Blurb.tsx
@@ -67,6 +67,11 @@ const SubmitButton = styled(RoundedButton)`
   }
 `
 
+interface PreviousZips {
+  id: string;
+  data: any;
+}
+
 export const Blurb: React.FC<{}> = () => {
   const { path, pushAddress } = useAppHistory()
   const { address } = AddressContainer.useContainer()
@@ -77,6 +82,9 @@ export const Blurb: React.FC<{}> = () => {
   // Also, need to use a state variable instead of a simpler ts variable
   // https://stackoverflow.com/a/56156394/8930600
   const [height, setHeight] = React.useState('100vh')
+
+  const [zips, setZips] = React.useState<PreviousZips[]>([])
+
   React.useEffect(() => {
     setHeight(`${window.innerHeight}px`)
   }, [])
@@ -86,10 +94,19 @@ export const Blurb: React.FC<{}> = () => {
     event.preventDefault()
     const zip = zipRef?.current?.value
     if (!zip) return
-    const resp = await client.fetchState(zip)
-    if (resp.type === 'error') return
-    pushAddress(resp.data, zip)
-    // TODO: handle error
+    const zipData = zips.find(element => element.id === zip)
+    if( zipData === undefined){
+      const resp = await client.fetchState(zip)
+      if (resp.type === 'error') return
+      // TODO: handle error
+      setZips(prevZips => ([
+        ...prevZips,
+        {id: zip, data: resp.data}
+      ]))
+      pushAddress(resp.data, zip)
+    } else {
+      pushAddress(zipData.data, zip)
+    }
   }
 
   const defaultValue = () => {


### PR DESCRIPTION
@tianhuil 
This small change avoids calls to `fetchState` if the user decides (or has a typo) on their postcode. Potentially saving at least 1 request to the google geocode API which can be expensive.

To check that it works go to [staging-site](https://mail-my-ballot.now.sh/) and input a zip code, then go back to the zip code input when the START button is pressed again there should be no call to trpc if the zipcode was already submitted.

Here's the [server site](https://ascendant-acre-138823.uc.r.appspot.com)