### PR TITLE
Fixes TypeError: Object.fromEntries is not a function

### DIFF
--- a/packages/client/src/lib/path.ts
+++ b/packages/client/src/lib/path.ts
@@ -2,6 +2,7 @@ import React from "react"
 import { useHistory, useLocation, matchPath } from "react-router-dom"
 import { pageView } from "./analytics"
 import { useDeepMemoize } from "./unstated"
+import { fromEntries } from "../common"
 
 export type QueryParams = Record<string, string>
 
@@ -91,7 +92,7 @@ const isEmpty = (query: QueryParams) => {
 }
 
 export const toUrl = <P extends Path>(path: P, query: QueryParams = {}): string => {
-  // arg -- can't get around this typecast  
+  // arg -- can't get around this typecast
   const rawUrl = (pathData[path.type] as PathDatum<P>).toRawUrl(path)
   const queryUrl = isEmpty(query) ?  '' : ('?' + new URLSearchParams(query).toString())
 
@@ -104,7 +105,7 @@ export const defaultUrl = toUrl({type:'start', oid:defaultOid})
 const rawToPath = <P extends Path>(
   url: string,
   pathEnum: PathEnum,
-  query: QueryParams, 
+  query: QueryParams,
   exact = false
 ): P | null => {
   const { path } = pathData[pathEnum]
@@ -131,7 +132,7 @@ const scrollToId = (id: string) => {
 }
 
 export const parseQS = (search: string): QueryParams => {
-  return Object.fromEntries((new URLSearchParams(search)).entries())
+  return fromEntries((new URLSearchParams(search)).entries()) as QueryParams
 }
 
 export const useAppHistory = () => {
@@ -140,7 +141,7 @@ export const useAppHistory = () => {
   const query = useDeepMemoize(parseQS(search))
   const path = useDeepMemoize(toPath(pathname, query))
   const oid = path?.oid || defaultOid
-  
+
   const pushScroll = React.useCallback((path: Path, query: QueryParams = {}) => {
     history.push(toUrl(path, query))
     scrollToId(pathData[path.type].scrollId)

--- a/packages/common/util.ts
+++ b/packages/common/util.ts
@@ -6,3 +6,41 @@ export type WithoutId<T extends {}> = Omit<T, 'id'>
 export type WithId<T extends {}> = T & {id: string}
 
 export const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+/**
+ * A wrapper with backward compatibility for Object.fromEntries that works
+ * as intended on older versions of TypeScript.
+ *
+ * @param entries The entries to be turned into an object, i.e. `[['key', 'value'], ...]`
+ */
+export const fromEntries = (
+  entries: IterableIterator<[string, string]> | unknown[][],
+): Record<string, unknown> => {
+  // The reason we write Object['fromEntries'], and not Object.fromEntries,
+  // is because machines without a recent version of TypeScript will fire
+  // an error complaining about the lack of this method.
+  if (Object['fromEntries']) {
+    return Object['fromEntries'](entries)
+  }
+
+  return Array.from(entries).reduce(
+    (accumulated, [ key, value ]) => {
+      return {...accumulated, [key as (string | symbol | number)]: value}
+    },
+    {},
+  )
+}
+
+/**
+ * A wrapper with backward compatibility for Array.flatMap that works as
+ * intended on older versions of TypeScript.
+ *
+ * @param array array to be flattened+mapped
+ * @param callbackfn function called on each element of the array
+ */
+export const flatMap = <T, U>(
+  array: T[],
+  callbackfn: (value: T, index: number, array: T[]) => U[],
+): U[] => {
+  return Array.prototype.concat(...array.map(callbackfn))
+}

--- a/packages/server/src/service/contact/loader.ts
+++ b/packages/server/src/service/contact/loader.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch'
 
-import { State, processEnvOrThrow, AvailableState, availableStates } from "../../common"
+import { State, processEnvOrThrow, AvailableState, availableStates, fromEntries } from "../../common"
 import { RawContactRecord, RawContact, ContactRecord } from "./type"
 import { normalizeStates } from "./normalize"
 
@@ -21,7 +21,7 @@ export const loadStates = async (): Promise<RawContactRecord> => {
   const startTime = new Date()
 
   const records = await Promise.all(availableStates.map(state => loadState(state)))
-  const ret = Object.fromEntries(records) as RawContactRecord
+  const ret = fromEntries(records) as RawContactRecord
 
   const endTime = new Date()
   const seconds = (endTime.getTime() - startTime.getTime()) / 1000.
@@ -32,10 +32,10 @@ export const loadStates = async (): Promise<RawContactRecord> => {
 export const loadMichigan = async (
   data: Record<string, RawContact>
 ): Promise<Record<string, RawContact & { key: string }>> => {
-  return Object.fromEntries(
+  return fromEntries(
     Object.entries(data)
       .map(([key, rec]) => [(rec as { fipscode: string }).fipscode, {...rec, key}])
-  )
+  ) as Record<string, RawContact & { key: string }>
 }
 
 // Utility Functions

--- a/packages/server/src/service/contact/normalize.ts
+++ b/packages/server/src/service/contact/normalize.ts
@@ -1,5 +1,5 @@
 import { RawContactRecord, ContactRecord, RawContact, OptionalLocale } from "./type"
-import { AvailableState } from "../../common"
+import { AvailableState, fromEntries } from "../../common"
 import { mandatoryTransform } from "./transformers"
 import { e164 } from '../twilio'
 
@@ -76,7 +76,7 @@ export const normalizeState = (
       normalizeContact(contact),
     ]
   )
-  return Object.fromEntries(array)
+  return fromEntries(array) as Record<string, RawContact>
 }
 
 export const normalizeStates = (records: RawContactRecord): ContactRecord => {
@@ -87,5 +87,5 @@ export const normalizeStates = (records: RawContactRecord): ContactRecord => {
       normalizeState(state, contactDatas)
     ]
   )
-  return Object.fromEntries(array)
+  return fromEntries(array) as ContactRecord
 }

--- a/packages/server/src/service/contact/search.ts
+++ b/packages/server/src/service/contact/search.ts
@@ -1,4 +1,4 @@
-import { Locale, AvailableState } from "../../common"
+import { Locale, AvailableState, flatMap } from "../../common"
 import { normalizeLocaleKey } from "./normalize"
 
 const citySuffixes = (suffixes: string[], city: string): string[] => {
@@ -71,16 +71,21 @@ export const keys = (
     case 'Michigan': {
       // In Michigan, first try 'administrative_area_level_3' (otherCities)
       // before 'locality' (city) and vary each them
-      const orderedCities = [
-        ...(locale?.otherCities ?? []),
-        locale.city
-      ].flatMap(michiganCitySuffixes)
+      const orderedCities = flatMap(
+        [
+          ...(locale?.otherCities ?? []),
+          locale.city
+        ],
+        michiganCitySuffixes,
+      )
+
       return orderedCities.map(city => normalizeLocaleKey({...locale, city}))
     }
     case 'Wisconsin': {
       if (!locale.county) return []
-      return wisconsinCounties(locale.county).flatMap(county =>
-        wisconsinCities(locale.city).map(city =>
+      return flatMap(
+        wisconsinCounties(locale.county),
+        county => wisconsinCities(locale.city).map(city =>
           normalizeLocaleKey({...locale, city, county})
         )
       )

--- a/packages/server/src/service/firestore.ts
+++ b/packages/server/src/service/firestore.ts
@@ -1,6 +1,6 @@
 import * as admin from 'firebase-admin'
 
-import { processEnvOrThrow, WithId } from '../common'
+import { processEnvOrThrow, WithId, fromEntries } from '../common'
 import { Profile } from 'passport'
 import { User, RichStateInfo, Org, TwilioResponse } from './types'
 import { Analytics } from '../common/analytics'
@@ -14,7 +14,7 @@ type Transaction = admin.firestore.Transaction
 const nonNullObject = (o: unknown): o is Record<string, unknown> => typeof o === 'object' && o !== null
 
 const removeUndefined = <T extends Record<string, unknown>>(obj: T): T => {
-  return Object.fromEntries(
+  return fromEntries(
     Object.entries(obj)
       .filter(
         ([_, val]) => val !== undefined
@@ -40,9 +40,9 @@ export class FirestoreService {
 
   // Firebase generates a warning if `admin.initializeApp` is called multiple times
   // However, if `projectId` is provided, (e.g. for testing), we do want to initialize app
-  // 
+  //
   // Warning Below:
-  // 
+  //
   // The default Firebase app already exists. This means you called initializeApp()
   // more than once without providing an app name as the second argument. In most
   // cases you only need to call initializeApp() once.But if you do want to initialize
@@ -58,7 +58,7 @@ export class FirestoreService {
           databaseURL: processEnvOrThrow('FIRESTORE_URL'),
         })
       }
-  
+
       this.db = admin.firestore()
     } else {
       this.db = admin.initializeApp({
@@ -94,7 +94,7 @@ export class FirestoreService {
       return {
         ...doc.data() as unknown as T,
         id: doc.id
-      } 
+      }
     })
   }
 
@@ -207,7 +207,7 @@ export class FirestoreService {
     await this.userRef(uid).set(user, { merge: true })
     return uid
   }
-  
+
   // claim (globally unique) org as role
   async claimNewOrg(uid: string, oid: string): Promise<boolean> {
     const newOrg: Org = {
@@ -228,7 +228,7 @@ export class FirestoreService {
     }
     return true
   }
-  
+
   // user grants another user membership in an org where they are an admin
   async grantExistingOrg(adminUid: string, newUid: string, oid: string): Promise<boolean> {
     if (adminUid == newUid) return false

--- a/packages/server/src/service/mg.ts
+++ b/packages/server/src/service/mg.ts
@@ -1,7 +1,7 @@
 import mailgun from 'mailgun-js'
 
 import { Letter } from './letter'
-import { processEnvOrThrow } from '../common'
+import { processEnvOrThrow, flatMap } from '../common'
 
 
 export const mg = mailgun({
@@ -48,11 +48,15 @@ export const toSignupEmailData = (
     'h:Reply-To': [processEnvOrThrow('MG_REPLY_TO_ADDR'), voterEmail, ...officialEmails].join(','),
   }
 
-  const attachment = [
-    signature ? makeImageAttachment(signature, 'signature', voterEmail) : [],
-    idPhoto ? makeImageAttachment(idPhoto, 'identification', voterEmail) : [],
-    pdfBuffer ? [new mg.Attachment({data: pdfBuffer, filename: 'letter.pdf'})] : []
-  ].flatMap(x => x)
+  const attachment = flatMap(
+    [
+      signature ? makeImageAttachment(signature, 'signature', voterEmail) : [],
+      idPhoto ? makeImageAttachment(idPhoto, 'identification', voterEmail) : [],
+      pdfBuffer ? [new mg.Attachment({data: pdfBuffer, filename: 'letter.pdf'})] : []
+    ],
+    x => x,
+  )
+
   return {
     to,
     subject,


### PR DESCRIPTION
For some reason on my local machine I wasn't able to start the development server successfully, whereas a remote one could. After checking the repo's issues I stumbled upon #11, which detailed exactly the problem I was having.

At least while coding, it seems that VSCode uses the type definitions & methods defined at `/usr/lib/code/extensions/node_modules/typescript/lib/lib.es5.d.ts`, which makes me believe Nodejs is doing something similar when running `yarn server gulp start` and thus not picking the correct updated version of TypeScript.

These sets of commits creates a backward-compatible fromEntries function and uses it in place of Object.fromEntries.