### PR TITLE
Reworks path.ts to allow code refactor

### DIFF
--- a/packages/client/src/comp/About.tsx
+++ b/packages/client/src/comp/About.tsx
@@ -9,7 +9,7 @@ import { Row, Col } from 'muicss/react'
 export const About = () => {
   const brandName = processEnvOrThrow('REACT_APP_BRAND_NAME')
   const url = processEnvOrThrow('REACT_APP_URL')
-  const { pushStart } = useAppHistory()
+  const { pushStartSection } = useAppHistory()
 
   return <div>
     <h1>About Us</h1>
@@ -21,7 +21,11 @@ export const About = () => {
       Vote at Home is a non-partisan 501(c)3 that empowers voters, letting them decide when, how and where they vote.
     </p>
     <SocialButtonWrapper>
-      <RoundedButton color='primary' variant='raised' onClick={pushStart}>
+      <RoundedButton
+        color='primary'
+        variant='raised'
+        onClick={() => pushStartSection('start')}
+      >
         <span>Get Started</span>
       </RoundedButton>
     </SocialButtonWrapper>

--- a/packages/client/src/comp/StateRedirect.tsx
+++ b/packages/client/src/comp/StateRedirect.tsx
@@ -4,13 +4,13 @@ import { client } from '../lib/trpc'
 import { AddressContainer, ContactContainer } from '../lib/unstated'
 
 export const StateRedirect = () => {
-  const { pushState, pushStart, query } = useAppHistory()
+  const { pushState, pushStartSection, query } = useAppHistory()
   const { registrationAddress } = query
   const { setAddress } = AddressContainer.useContainer()
   const { setContact } = ContactContainer.useContainer()
 
   React.useEffect(() => {
-    if (!registrationAddress) { return pushStart() }
+    if (!registrationAddress) { return pushStartSection('start') }
     (async () => {
       const result = await client.fetchContactAddress(registrationAddress)
       if (result.type === 'data') {
@@ -19,9 +19,9 @@ export const StateRedirect = () => {
         setContact(contact)
         return pushState(address.state)
       } else {
-        return pushStart()
+        return pushStartSection('start')
       }
     })()
-  }, [registrationAddress, pushStart, pushState, setAddress, setContact])
+  }, [registrationAddress, pushStartSection, pushState, setAddress, setContact])
   return <></>
 }

--- a/packages/client/src/comp/Success.tsx
+++ b/packages/client/src/comp/Success.tsx
@@ -14,7 +14,7 @@ const BlueH2 = styled.h2`
 `
 
 export const Success: React.FC = () => {
-  const { pushStart } = useAppHistory()
+  const { pushStartSection } = useAppHistory()
   const { id } = useParams()
 
   return <div>
@@ -27,7 +27,11 @@ export const Success: React.FC = () => {
       <p>Check your inbox for the signup email and <b>Reply All</b> with &ldquo;<i>I confirm this request.</i>&rdquo;  (This is not strictly necessary but election officials appreciate the confirmation.)</p>
     </StyledPanel>
     <Center>
-      <RoundedButton color='primary' variant='raised' onClick={pushStart}>
+      <RoundedButton
+        color='primary'
+        variant='raised'
+        onClick={() => pushStartSection('start')}
+      >
         Start Over
       </RoundedButton>
     </Center>

--- a/packages/client/src/comp/states/StateForm.tsx
+++ b/packages/client/src/comp/states/StateForm.tsx
@@ -58,17 +58,17 @@ interface Props {
 export const StateForm: React.FC<Props> = ({ignoreError}) => {
   const { address, locale } = AddressContainer.useContainer()
   const { contact, method } = ContactContainer.useContainer()
-  const { path, pushAddress, pushStart } = useAppHistory()
+  const { path, pushAddress, pushStartSection } = useAppHistory()
 
   // if we do not have locale or address data, go back
   if (!locale || !address) {
     if (ignoreError) return null
     if (!path) {
-      pushStart()
+      pushStartSection('start')
     } else if (path.type === 'state') {
       pushAddress(path.state)
     } else {
-      pushStart()
+      pushStartSection('start')
     }
     return null
   }


### PR DESCRIPTION
Instead of declaring one type and pushFunction for each Path inside the starting page, we can now use a single function to push any section to the appHistory.

Note that this is intended to be used on the redesign and currently does not shows a lot of benefits on the master branch.