### PR TITLE
Loading Indicators

### DIFF
--- a/packages/client/src/comp/AddressForm.tsx
+++ b/packages/client/src/comp/AddressForm.tsx
@@ -3,7 +3,7 @@ import Input from 'muicss/lib/react/input'
 
 import { RoundedButton } from './util/Button'
 import { client } from '../lib/trpc'
-import { AddressContainer, ContactContainer } from '../lib/unstated'
+import { AddressContainer, ContactContainer, FetchingDataContainer } from '../lib/unstated'
 import { useControlRef } from './util/ControlRef'
 import { TimeoutError } from '@tianhuil/simple-trpc/dist/timedFetch'
 import { BaseInput } from './util/Input'
@@ -44,7 +44,7 @@ export const RawAddressForm: React.FC<{rawState: string, zip?: string}> = ({rawS
   const addrRef = useControlRef<Input>()
   const { address, setAddress } = AddressContainer.useContainer()
   const { setContact } = ContactContainer.useContainer()
-  const [fetchingData, setFetchingData] = React.useState(false)
+  const { fetchingData, setFetchingData } = FetchingDataContainer.useContainer()
 
 
   // When we first arrive at page, set focus and move cursor to beginning
@@ -84,19 +84,16 @@ export const RawAddressForm: React.FC<{rawState: string, zip?: string}> = ({rawS
     if (addr === null) throw Error('address ref not set')
     if (!state) throw Error('This can never happen: already checked if state is valid')
 
-    toast.info('Searching data for the address')
     setFetchingData(true)
     try {
       setContact(null)
       setAddress(null)
       const result = await client.fetchContactAddress(addr)
-      toast.dismiss()
       switch(result.type) {
         case 'data': {
           const {contact, address} = result.data
           setContact(contact)
           setAddress(address)
-
 
           break
         }
@@ -106,7 +103,6 @@ export const RawAddressForm: React.FC<{rawState: string, zip?: string}> = ({rawS
         }
       }
       pushState(state)
-      toast.dismiss()
     } catch(e) {
       toast.dismiss()
       if (e instanceof TimeoutError) {

--- a/packages/client/src/comp/Blurb.tsx
+++ b/packages/client/src/comp/Blurb.tsx
@@ -5,7 +5,7 @@ import { RoundedButton } from './util/Button'
 import { StyleContainer } from './util/Container'
 import { useAppHistory } from '../lib/path'
 import { client } from '../lib/trpc'
-import { AddressContainer } from '../lib/unstated'
+import { AddressContainer, FetchingDataContainer } from '../lib/unstated'
 import { AppForm } from './util/Form'
 
 
@@ -70,7 +70,7 @@ export const Blurb: React.FC<{}> = () => {
   const { path, pushAddress } = useAppHistory()
   const { address } = AddressContainer.useContainer()
   const zipRef = React.useRef<HTMLInputElement>(null)
-  const [fetchingData, setFetchingData] = React.useState(false)
+  const { fetchingData, setFetchingData } = FetchingDataContainer.useContainer()
 
   // mobile browsers don't support 100vh, so use this trick instead
   // https://chanind.github.io/javascript/2019/09/28/avoid-100vh-on-mobile-web.html

--- a/packages/client/src/comp/StateContainer.tsx
+++ b/packages/client/src/comp/StateContainer.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { HashRouter } from 'react-router-dom'
 import { Slide, ToastContainer } from "react-toastify"
 import { ModalProvider } from 'styled-react-modal'
-import { AddressContainer, ContactContainer, AnalyticsContainer, VoterContainer, FeatureFlagsContainer } from '../lib/unstated'
+import { AddressContainer, ContactContainer, AnalyticsContainer, VoterContainer, FeatureFlagsContainer, FetchingDataContainer } from '../lib/unstated'
 
 import 'react-toastify/dist/ReactToastify.css'
 
@@ -24,19 +24,21 @@ export const UnstatedContainer: React.FC<{}> = ({ children }) => (<HashRouter>
         <FeatureFlagsContainer.Provider>
           <VoterContainer.Provider>
             <ModalProvider>
-              {children}
-              <CustomToastContainer
-                position="top-right"
-                autoClose={3000}
-                hideProgressBar={true}
-                newestOnTop={true}
-                closeOnClick={true}
-                rtl={false}
-                limit={2}
-                pauseOnFocusLoss={true}
-                pauseOnHover={true}
-                transition={Slide}
-              />
+              <FetchingDataContainer.Provider>
+                {children}
+                <CustomToastContainer
+                  position="top-right"
+                  autoClose={3000}
+                  hideProgressBar={true}
+                  newestOnTop={true}
+                  closeOnClick={true}
+                  rtl={false}
+                  limit={2}
+                  pauseOnFocusLoss={true}
+                  pauseOnHover={true}
+                  transition={Slide}
+                />
+              </FetchingDataContainer.Provider>
             </ModalProvider>
           </VoterContainer.Provider>
         </FeatureFlagsContainer.Provider>

--- a/packages/client/src/comp/StateContainer.tsx
+++ b/packages/client/src/comp/StateContainer.tsx
@@ -6,6 +6,7 @@ import { ModalProvider } from 'styled-react-modal'
 import { AddressContainer, ContactContainer, AnalyticsContainer, VoterContainer, FeatureFlagsContainer, FetchingDataContainer } from '../lib/unstated'
 
 import 'react-toastify/dist/ReactToastify.css'
+import { LoadingOverlay } from './util/LoadingOverlay'
 
 const CustomToastContainer = styled(ToastContainer)`
   @media screen and (min-width: 592px) {
@@ -26,6 +27,7 @@ export const UnstatedContainer: React.FC<{}> = ({ children }) => (<HashRouter>
             <ModalProvider>
               <FetchingDataContainer.Provider>
                 {children}
+                <LoadingOverlay/>
                 <CustomToastContainer
                   position="top-right"
                   autoClose={3000}

--- a/packages/client/src/comp/states/Base.tsx
+++ b/packages/client/src/comp/states/Base.tsx
@@ -9,7 +9,7 @@ import { BaseInput, PhoneInput, EmailInput, NameInput, BirthdateInput } from '..
 import { Togglable } from '../util/Togglable'
 import { useAppHistory } from '../../lib/path'
 import { Signature } from '../util/Signature'
-import { AddressContainer, VoterContainer, ContactContainer } from '../../lib/unstated'
+import { AddressContainer, VoterContainer, ContactContainer, FetchingDataContainer } from '../../lib/unstated'
 import { ContactInfo } from '../contact/ContactInfo'
 import { AppForm } from '../util/Form'
 import { Center } from '../util/Util'
@@ -32,7 +32,7 @@ export const Base = <Info extends StateInfo>({ enrichValues, children }: Props<I
   const { address, locale } = AddressContainer.useContainer()
   const { contact } = ContactContainer.useContainer()
   const { voter } = VoterContainer.useContainer()
-  const [fetchingData, setFetchingData] = React.useState(false)
+  const { fetchingData, setFetchingData } = FetchingDataContainer.useContainer()
 
   const nameRef = useControlRef<Input>()
   const birthdateRef = useControlRef<Input>()
@@ -76,14 +76,11 @@ export const Base = <Info extends StateInfo>({ enrichValues, children }: Props<I
       toast.error('Please fill all the required fields in the right formats')
       return
     }
-    toast.info('Signup in progress')
     setFetchingData(true)
     const result = await client.register(info, voter)
     setFetchingData(false)
-    toast.dismiss()
     if(result.type === 'data'){
       pushSuccess(result.data)
-
     } else {
       toast.error('Error signing up.  Try resubmitting.  If this persists, try again in a little while.')
     }

--- a/packages/client/src/comp/states/Base.tsx
+++ b/packages/client/src/comp/states/Base.tsx
@@ -49,7 +49,6 @@ export const Base = <Info extends StateInfo>({ enrichValues, children }: Props<I
     event.preventDefault()
 
     if (!address || !uspsAddress || !contact) {
-      toast.dismiss()
       toast.error('Please fill all the required fields')
       return
     }

--- a/packages/client/src/comp/util/LoadingOverlay.tsx
+++ b/packages/client/src/comp/util/LoadingOverlay.tsx
@@ -21,6 +21,7 @@ const OverlayStyle = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: wait;
 
   i {
     font-size: 32px;

--- a/packages/client/src/comp/util/LoadingOverlay.tsx
+++ b/packages/client/src/comp/util/LoadingOverlay.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import styled, { keyframes } from 'styled-components'
+import { FetchingDataContainer } from '../../lib/unstated'
+
+const fadeIn = keyframes`
+  from { opacity: 0 }
+  to { opacity: 1 }
+`
+
+const OverlayStyle = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 99;
+
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(255, 255, 255, 0.6);
+  animation: ${fadeIn} ease .3s both;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  i {
+    font-size: 32px;
+    color: #2592f6;
+    text-shadow: 0 0 6px #2592f677;
+  }
+`
+
+export const LoadingOverlay: React.FC = () => {
+  const { fetchingData } = FetchingDataContainer.useContainer()
+  if (fetchingData) {
+    return <OverlayStyle id='loadingIndicatorOverlay'>
+      <i className="fa fa-circle-o-notch fa-spin"/>
+    </OverlayStyle>
+  }
+  return null
+}

--- a/packages/client/src/comp/util/Upload.test.tsx
+++ b/packages/client/src/comp/util/Upload.test.tsx
@@ -4,15 +4,19 @@ import { Upload } from './Upload'
 
 import { render, fireEvent, wait, act } from '@testing-library/react'
 import { mocked } from 'ts-jest/utils'
+import { UnstatedContainer } from '../StateContainer'
 
 describe('Upload', () => {
   const setup = (maxSizeMB: number) => {
     const setDataString = jest.fn<void, [string]>()
-    const { getByTestId } = render(<Upload
-      label='label'
-      setDataString={setDataString}
-      maxSizeMB={maxSizeMB}
-    />)
+    const { getByTestId } = render(
+      <Upload
+        label='label'
+        setDataString={setDataString}
+        maxSizeMB={maxSizeMB}
+      />,
+      { wrapper: UnstatedContainer }
+    )
 
     const clickInputSpy = jest.spyOn(HTMLInputElement.prototype, 'click')
         mocked(window, true).alert = jest.fn()

--- a/packages/client/src/comp/util/Upload.tsx
+++ b/packages/client/src/comp/util/Upload.tsx
@@ -4,6 +4,7 @@ import { GoldRatioOutline } from './Outline'
 import styled from 'styled-components'
 import { Muted } from './Text'
 import { compressImage } from '../../lib/compressImage'
+import { FetchingDataContainer } from '../../lib/unstated'
 
 const toDataUrl = (file: File): Promise<string> => {
   return new Promise((resolve, reject) => {
@@ -45,7 +46,7 @@ export const Upload: React.FC<Props> = ({
 }) => {
   const ref = React.useRef<HTMLInputElement | null>()
   const [image, setImage] = React.useState<ImageDetails>()
-  const [loading, setLoading] = React.useState(false)
+  const { setFetchingData } = FetchingDataContainer.useContainer()
 
   const onClick = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
     event.preventDefault()
@@ -55,7 +56,7 @@ export const Upload: React.FC<Props> = ({
   const maxSizeMBReal = maxSizeMB ?? 1
 
   const onChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    setLoading(true)
+    setFetchingData(true)
 
     if (event.target.files && event.target.files.length > 0) {
       const file = event.target.files[0]
@@ -66,7 +67,7 @@ export const Upload: React.FC<Props> = ({
       setDataString(compressed)
     }
 
-    setLoading(false)
+    setFetchingData(false)
   }
 
   const centerBlock: React.CSSProperties = {
@@ -77,13 +78,6 @@ export const Upload: React.FC<Props> = ({
 
   // The content displayed inside GoldenRatioOutline
   const OutlineChild = () => {
-    if (loading) {
-      return <i
-        className="fa fa-circle-o-notch fa-spin"
-        style={{ fontSize: 32, color: '#2592f655' }}
-      />
-    }
-
     if (image) {
       return <>
         <img src={image.data} style={{maxHeight: '40%'}} alt='thumbnail'/>

--- a/packages/client/src/index.scss
+++ b/packages/client/src/index.scss
@@ -19,6 +19,7 @@ body {
     font-size:      16px;
     line-height:    1.5
   }
+  cursor: var(--pageCursor);
 }
 
 h1, h2, h3, h4 {
@@ -34,7 +35,7 @@ h1 {
   padding-top:    120px;
   @media only screen and (max-width: 544px) {
     font-size:      32px;
-    line-height:    42px;  
+    line-height:    42px;
     padding-top:    40px;
   }
 }
@@ -44,7 +45,7 @@ h2 {
   line-height:  48px;
   @media only screen and (max-width: 544px) {
     font-size:      24px;
-    line-height:    32px;  
+    line-height:    32px;
   }
 }
 
@@ -53,7 +54,7 @@ h3 {
   line-height:  42px;
   @media only screen and (max-width: 544px) {
     font-size:      20px;
-    line-height:    28px;  
+    line-height:    28px;
   }
 }
 

--- a/packages/client/src/index.scss
+++ b/packages/client/src/index.scss
@@ -19,7 +19,6 @@ body {
     font-size:      16px;
     line-height:    1.5
   }
-  cursor: var(--pageCursor);
 }
 
 h1, h2, h3, h4 {

--- a/packages/client/src/lib/unstated/index.ts
+++ b/packages/client/src/lib/unstated/index.ts
@@ -31,5 +31,40 @@ const useFeatureFlagsContainer = (initialFeatureFlags: FeatureFlags | null = nul
 
 export const FeatureFlagsContainer = createContainer(useFeatureFlagsContainer)
 
+/**
+ * When true replaces the mouse cursor with the operating system's default
+ * for loading information.
+ */
+const useFetchingDataContainer = (initialFetching = false) => {
+  const [fetchingData, setFetchingData] = React.useState(initialFetching)
+
+  const handleChanges = (fetching: boolean, waitForPromise?: Promise<unknown>) => {
+    const cursor = fetching ? 'wait' : 'initial'
+    document.documentElement.style.setProperty('--pageCursor', cursor)
+    setFetchingData(fetching)
+
+    waitForPromise?.then(() => {
+      setFetchingData(false)
+      document.documentElement.style.setProperty('--pageCursor', 'initial')
+    })
+  }
+
+  return {
+    fetchingData,
+    /**
+     * Allows to change the cursor being displayed on screen, when fetchingData
+     * is true it changes to match the OS default cursor for loading data.
+     *
+     * @param fetching The state which fetchingData will be set, will override
+     * previous values
+     * @param waitForPromise Upon completion of the promise automatically sets
+     * fetchingData to false
+     */
+    setFetchingData: handleChanges,
+  }
+}
+
+export const FetchingDataContainer = createContainer(useFetchingDataContainer)
+
 export * from './voter'
 export * from './memoize'

--- a/packages/client/src/lib/unstated/index.ts
+++ b/packages/client/src/lib/unstated/index.ts
@@ -38,30 +38,7 @@ export const FeatureFlagsContainer = createContainer(useFeatureFlagsContainer)
 const useFetchingDataContainer = (initialFetching = false) => {
   const [fetchingData, setFetchingData] = React.useState(initialFetching)
 
-  const handleChanges = (fetching: boolean, waitForPromise?: Promise<unknown>) => {
-    const cursor = fetching ? 'wait' : 'initial'
-    document.documentElement.style.setProperty('--pageCursor', cursor)
-    setFetchingData(fetching)
-
-    waitForPromise?.then(() => {
-      setFetchingData(false)
-      document.documentElement.style.setProperty('--pageCursor', 'initial')
-    })
-  }
-
-  return {
-    fetchingData,
-    /**
-     * Allows to change the cursor being displayed on screen, when fetchingData
-     * is true it changes to match the OS default cursor for loading data.
-     *
-     * @param fetching The state which fetchingData will be set, will override
-     * previous values
-     * @param waitForPromise Upon completion of the promise automatically sets
-     * fetchingData to false
-     */
-    setFetchingData: handleChanges,
-  }
+  return { fetchingData, setFetchingData }
 }
 
 export const FetchingDataContainer = createContainer(useFetchingDataContainer)


### PR DESCRIPTION
- [x] Replaces cursor with a loading indicator when fetching data;
- [x] No longer trigger unnecessary toasts on `Base.tx`;
- [x] No longer trigger unnecessary toasts on `AddressForm.tx`;
- [x] No longer trigger unnecessary toasts on `Blurb.tx`;
- [x] Create a similar effect for mobile devices;
- [x] See why tests are failing and fix them;
- [x] Decide whether to use the overlay globally (then remove the device detection algorithm);
- [x] See if we should use this effect when compressing images;

If I'm missing any Component or place where these indicators would be useful, please let me know.

Cheers!

https://lu-mmb.ludanin.vercel.app