### PR TITLE
Use content-id for signatures

### DIFF
--- a/packages/server/src/service/letter/index.ts
+++ b/packages/server/src/service/letter/index.ts
@@ -4,13 +4,14 @@ import nunjucks from 'nunjucks'
 import { processEnvOrThrow, StateInfo, ContactMethod, ImplementedState } from '../../common'
 import { fillNewHampshire } from '../pdfForm'
 import { fillNorthCarolina } from '../pdfForm'
+import { makeImageAttachment } from '../mg'
 
 nunjucks.configure(__dirname + '/views', {
   autoescape: true,
   noCache: !!process.env.NUNJUNKS_DISABLE_CACHE
 })
 
-interface Options { 
+interface Options {
   signature?: string
   idPhoto?: string
   form?: Buffer
@@ -97,7 +98,13 @@ export const toLetter = async (
         ...envVars,
         confirmationId,
         method,
-        warning: !process.env.EMAIL_FAX_OFFICIALS
+        warning: !process.env.EMAIL_FAX_OFFICIALS,
+        signatureFile: info.signature
+          ? makeImageAttachment(info.signature, 'signature', '')[0].filename
+          : undefined,
+        idPhotoFile: info.idPhoto
+          ? makeImageAttachment(info.idPhoto, 'identification', '')[0].filename
+          : undefined,
       }
     ),
     method,

--- a/packages/server/src/service/letter/views/Base.md
+++ b/packages/server/src/service/letter/views/Base.md
@@ -20,7 +20,7 @@ Sincerely,
 
 {{name}}{% if signature %} (Signature Below and Attached)
 
-<img style='max-width: 400px;' src='{{signature}}'/>
+<img style='max-width: 400px;' src='cid:{{signatureFile}}'/>
 {% endif %}
 
 <font style='font-size:75%;'>

--- a/packages/server/src/service/mg.ts
+++ b/packages/server/src/service/mg.ts
@@ -3,13 +3,12 @@ import mailgun from 'mailgun-js'
 import { Letter } from './letter'
 import { processEnvOrThrow } from '../common'
 
-
 export const mg = mailgun({
   domain: processEnvOrThrow('MG_DOMAIN'),
   apiKey: processEnvOrThrow('MG_API_KEY'),
 })
 
-const makeImageAttachment = (
+export const makeImageAttachment = (
   image: string,
   filename: string,  // without file extension
   to: string,        // just for error reporting
@@ -58,6 +57,7 @@ export const toSignupEmailData = (
     html,
     text: md,
     attachment,
+    inline: attachment,
     ...mgData,
   }
 }


### PR DESCRIPTION
- [x] It works on both Gmail and Outlook;
- [x] It works on both jpeg and png;
- [ ] Understand why staging isn't updating;

I'm having some troubles to understand why my staging version isn't updating with the newest changes, I've redeployed the app to App Engine twice and the email still doesn't show embedded images--but if you run locally it works.

I'm going to recheck the envs and see if I can sort these things out so you guys can test the changes without having to run it locally.

Cheers!